### PR TITLE
(feat) Refactor builtin formatters to allow easy extend of custom fields formatting

### DIFF
--- a/example/console_example.dart
+++ b/example/console_example.dart
@@ -6,7 +6,7 @@ library example.console;
 import 'package:jetlog/formatters.dart' show TextFormatter;
 import 'package:jetlog/handlers.dart' show ConsoleHandler;
 import 'package:jetlog/jetlog.dart'
-    show Level, Logger, Str, DefaultLog;
+    show DefaultLog, Level, Logger, Str;
 
 final _logger = Logger.detached()
   ..level = Level.all

--- a/lib/formatters.dart
+++ b/lib/formatters.dart
@@ -1,6 +1,6 @@
 library jetlog.formatters;
 
 export 'src/formatters/formatter.dart'
-    show Formatter, TimestampFormatter, LevelFormatter, FieldsFormatter;
+    show Formatter, TimestampFormatter, LevelFormatter, FormatterBase;
 export 'src/formatters/json_formatter.dart' show JsonFormatter;
 export 'src/formatters/text_formatter.dart' show TextFormatter;

--- a/lib/src/formatters/formatter.dart
+++ b/lib/src/formatters/formatter.dart
@@ -7,14 +7,21 @@ typedef FieldFormatter<R> = R Function(Field<Object>);
 /// [Formatter] is capable to format single [Record] entry.
 typedef Formatter = List<int> Function(Record);
 
+/// Base mixin for implementing [Formatter].
 ///
+/// Contains default implementations of common methods across formatters.
 mixin FormatterBase<R> {
   final Map<FieldKind, FieldFormatter<R>> _registeredFieldFormatters = {};
 
+  /// Registers [formatter] for a given field [kind].
   void setFieldFormatter(FieldKind kind, FieldFormatter<R> formatter) {
     _registeredFieldFormatters[kind] = formatter;
   }
 
+  /// Returns registered formatter for a give field [kind].
+  ///
+  /// If no formatter is registered for given field [kind] throws an
+  /// appropriated [StateError].
   FieldFormatter<R> getFieldFormatter(FieldKind kind) {
     final formatter = _registeredFieldFormatters[kind];
     if (formatter == null) {

--- a/lib/src/formatters/formatter.dart
+++ b/lib/src/formatters/formatter.dart
@@ -1,8 +1,26 @@
-import 'package:jetlog/jetlog.dart' show Record, Level, Field;
+import 'package:jetlog/jetlog.dart' show Record, Level, Field, FieldKind;
 
-typedef LevelFormatter<L> = L Function(Level);
-typedef TimestampFormatter<T> = T Function(DateTime);
-typedef FieldsFormatter<F> = F Function(Iterable<Field>);
+typedef LevelFormatter<R> = R Function(Level);
+typedef TimestampFormatter<R> = R Function(DateTime);
+typedef FieldFormatter<R> = R Function(Field<Object>);
 
 /// [Formatter] is capable to format single [Record] entry.
 typedef Formatter = List<int> Function(Record);
+
+mixin FormatterBase<R> {
+  final Map<FieldKind, FieldFormatter<R>> _registeredFieldFormatters = {};
+
+  void setFieldFormatter(FieldKind kind, FieldFormatter<R> formatter) {
+    _registeredFieldFormatters[kind] = formatter;
+  }
+
+  FieldFormatter<R> getFieldFormatter(FieldKind kind) {
+    final formatter = _registeredFieldFormatters[kind];
+    if (formatter == null) {
+      throw StateError(
+          'No registered formatters were provided for given field kind $kind!');
+    }
+
+    return formatter;
+  }
+}

--- a/lib/src/formatters/formatter.dart
+++ b/lib/src/formatters/formatter.dart
@@ -7,6 +7,7 @@ typedef FieldFormatter<R> = R Function(Field<Object>);
 /// [Formatter] is capable to format single [Record] entry.
 typedef Formatter = List<int> Function(Record);
 
+///
 mixin FormatterBase<R> {
   final Map<FieldKind, FieldFormatter<R>> _registeredFieldFormatters = {};
 

--- a/lib/src/formatters/json_formatter.dart
+++ b/lib/src/formatters/json_formatter.dart
@@ -64,9 +64,9 @@ class JsonFormatter with FormatterBase<MapEntry<String, Object>> {
   @pragma('vm:prefer-inline')
   void _init() {
     setFieldFormatter(FieldKind.boolean, _formatPrimitiveField);
-    setFieldFormatter(FieldKind.dateTime, _formatPrimitiveField);
+    setFieldFormatter(FieldKind.dateTime, _formatPrimitiveFieldToString);
     setFieldFormatter(FieldKind.double, _formatPrimitiveField);
-    setFieldFormatter(FieldKind.duration, _formatPrimitiveField);
+    setFieldFormatter(FieldKind.duration, _formatPrimitiveFieldToString);
     setFieldFormatter(FieldKind.integer, _formatPrimitiveField);
     setFieldFormatter(FieldKind.number, _formatPrimitiveField);
     setFieldFormatter(FieldKind.string, _formatPrimitiveField);
@@ -101,6 +101,11 @@ class JsonFormatter with FormatterBase<MapEntry<String, Object>> {
 
   @pragma('vm:prefer-inline')
   MapEntry<String, Object> _formatPrimitiveField(Field<dynamic> field) =>
+      MapEntry(field.name, field.value);
+
+  @pragma('vm:prefer-inline')
+  MapEntry<String, Object> _formatPrimitiveFieldToString(
+          Field<dynamic> field) =>
       MapEntry(field.name, field.value.toString());
 
   List<int> call(Record record) {

--- a/lib/src/formatters/json_formatter.dart
+++ b/lib/src/formatters/json_formatter.dart
@@ -39,10 +39,11 @@ class JsonFormatter with FormatterBase<MapEntry<String, Object>> {
   }
 
   factory JsonFormatter.withIndent(final int indent,
-          {LevelFormatter<Object> formatLevel = _formatLevel,
+          {bool useTabs = false,
+          LevelFormatter<Object> formatLevel = _formatLevel,
           TimestampFormatter<Object> formatTimestamp = _formatTimestamp}) =>
-      JsonFormatter._(
-          JsonEncoder.withIndent(' ' * indent), formatLevel, formatTimestamp);
+      JsonFormatter._(JsonEncoder.withIndent((useTabs ? '\t' : ' ') * indent),
+          formatLevel, formatTimestamp);
 
   final Utf8Encoder _utf8;
   final JsonEncoder _json;

--- a/lib/src/formatters/json_formatter.dart
+++ b/lib/src/formatters/json_formatter.dart
@@ -12,11 +12,12 @@ String _formatTimestamp(DateTime timestamp) => timestamp.toString();
 
 /// [JsonFormatter] is used to encode [Record] to JSON format.
 ///
-/// Known pitfall is that this formatter de-duplicates and overrides
-/// collapsing fields. Using the same key multiple time results only to
-/// single field is included to the final output. As such we strongly recommend
-/// not to put fields in to any collections fields with key such as `level`,
-/// `message`, `name` and `timestamp`.
+/// Make sure that no fields with overlapping names are provided as
+/// formatter de-duplicates collapsing fields, i.e. providing fields with
+/// the same key results only to a single field is include into the output.
+///
+/// As such we strongly recommend not to put fields in to any collections
+/// fields with key such as `level`, `message`, `name` and `timestamp`.
 class JsonFormatter with FormatterBase<MapEntry<String, Object>> {
   JsonFormatter._(this._json, this.formatLevel, this.formatTimestamp)
       : _utf8 = const Utf8Encoder() {
@@ -25,9 +26,8 @@ class JsonFormatter with FormatterBase<MapEntry<String, Object>> {
 
   /// Creates a new [JsonFormatter].
   ///
-  /// Optional [formatLevel], [formatTimestamp] and [formatFields] callbacks
-  /// may be provided used to format severity levels, timestamp and collection
-  /// fields respectively.
+  /// Optional [formatLevel] and [formatTimestamp] callbacks
+  /// may be provided and are used to format severity levels and timestamp.
   // ignore: sort_unnamed_constructors_first
   factory JsonFormatter(
       {LevelFormatter<Object> formatLevel = _formatLevel,
@@ -38,7 +38,14 @@ class JsonFormatter with FormatterBase<MapEntry<String, Object>> {
     return formatter;
   }
 
-  factory JsonFormatter.withIndent(final int indent,
+  /// Creates a new [JsonFormatter] with specified [indent] level.
+  ///
+  /// By default produced JSON is indented with space character, however
+  /// it is possible to use tabs instead by setting [useTabs] to `true`.
+  ///
+  /// Optional [formatLevel] and [formatTimestamp] callbacks
+  /// may be provided and are used to format severity levels and timestamp.
+  factory JsonFormatter.withIndent(int indent,
           {bool useTabs = false,
           LevelFormatter<Object> formatLevel = _formatLevel,
           TimestampFormatter<Object> formatTimestamp = _formatTimestamp}) =>

--- a/lib/src/formatters/json_formatter.dart
+++ b/lib/src/formatters/json_formatter.dart
@@ -3,6 +3,13 @@ import 'dart:convert' show JsonEncoder, Utf8Encoder;
 import 'package:jetlog/jetlog.dart' show Field, FieldKind, Level, Obj, Record;
 import 'package:jetlog/src/formatters/formatter.dart';
 
+@pragma('vm:prefer-inline')
+Map<String, Object> _formatLevel(Level level) =>
+    <String, Object>{'name': level.name, 'severity': level.value};
+
+@pragma('vm:prefer-inline')
+String _formatTimestamp(DateTime timestamp) => timestamp.toString();
+
 /// [JsonFormatter] is used to encode [Record] to JSON format.
 ///
 /// Known pitfall is that this formatter de-duplicates and overrides
@@ -10,70 +17,93 @@ import 'package:jetlog/src/formatters/formatter.dart';
 /// single field is included to the final output. As such we strongly recommend
 /// not to put fields in to any collections fields with key such as `level`,
 /// `message`, `name` and `timestamp`.
-class JsonFormatter {
+class JsonFormatter with FormatterBase<MapEntry<String, Object>> {
+  JsonFormatter._(this._json, this.formatLevel, this.formatTimestamp)
+      : _utf8 = const Utf8Encoder() {
+    _init();
+  }
+
   /// Creates a new [JsonFormatter].
   ///
   /// Optional [formatLevel], [formatTimestamp] and [formatFields] callbacks
   /// may be provided used to format severity levels, timestamp and collection
   /// fields respectively.
-  ///
-  /// Optional [indent] value may be also provided, which denotes size of
-  /// common indentation (per level indentation) each blocks is prepended with.
-  JsonFormatter(
-      {this.formatLevel = _formatLevel,
-      this.formatTimestamp = _formatTimestamp,
-      this.formatFields = _formatFields,
-      int indent})
-      : _utf8 = const Utf8Encoder(),
-        _json = indent != null
-            ? JsonEncoder.withIndent(' ' * indent)
-            : const JsonEncoder();
+  // ignore: sort_unnamed_constructors_first
+  factory JsonFormatter(
+      {LevelFormatter<Object> formatLevel = _formatLevel,
+      TimestampFormatter<Object> formatTimestamp = _formatTimestamp}) {
+    final formatter =
+        JsonFormatter._(const JsonEncoder(), formatLevel, formatTimestamp);
+
+    return formatter;
+  }
+
+  factory JsonFormatter.withIndent(final int indent,
+          {LevelFormatter<Object> formatLevel = _formatLevel,
+          TimestampFormatter<Object> formatTimestamp = _formatTimestamp}) =>
+      JsonFormatter._(
+          JsonEncoder.withIndent(' ' * indent), formatLevel, formatTimestamp);
 
   final Utf8Encoder _utf8;
   final JsonEncoder _json;
 
-  final LevelFormatter<dynamic> formatLevel;
-  final TimestampFormatter<dynamic> formatTimestamp;
-  final FieldsFormatter<Map<String, dynamic>> formatFields;
+  final LevelFormatter<Object> formatLevel;
+  final TimestampFormatter<Object> formatTimestamp;
 
   /// Returns a default [JSONFormatter].
   static JsonFormatter get defaultFormatter => JsonFormatter();
 
+  @pragma('vm:prefer-inline')
+  void _init() {
+    setFieldFormatter(FieldKind.boolean, _formatPrimitiveField);
+    setFieldFormatter(FieldKind.dateTime, _formatPrimitiveField);
+    setFieldFormatter(FieldKind.double, _formatPrimitiveField);
+    setFieldFormatter(FieldKind.duration, _formatPrimitiveField);
+    setFieldFormatter(FieldKind.integer, _formatPrimitiveField);
+    setFieldFormatter(FieldKind.number, _formatPrimitiveField);
+    setFieldFormatter(FieldKind.string, _formatPrimitiveField);
+    setFieldFormatter(FieldKind.object, _formatObjectField);
+  }
+
+  Iterable<MapEntry<String, Object>> _formatFields(Iterable<Field> fields) {
+    if (fields == null || fields.isEmpty) {
+      return null;
+    }
+
+    final entries = <MapEntry<String, Object>>[];
+
+    for (final field in fields) {
+      final handler = getFieldFormatter(field.kind);
+      entries.add(handler(field));
+    }
+
+    return entries;
+  }
+
+  @pragma('vm:prefer-inline')
+  MapEntry<String, Object> _formatObjectField(Field field) {
+    final entries = _formatFields((field as Obj).value);
+    final name = field.name;
+    if (entries != null) {
+      return MapEntry(name, Map.fromEntries(entries));
+    }
+
+    return MapEntry(name, null);
+  }
+
+  @pragma('vm:prefer-inline')
+  MapEntry<String, Object> _formatPrimitiveField(Field<dynamic> field) =>
+      MapEntry(field.name, field.value.toString());
+
   List<int> call(Record record) {
-    final fields = formatFields(record.fields);
-    final dict = <String, dynamic>{
-      'level': formatLevel(record.level),
-      'message': record.message,
-      'name': record.name,
-      'timestamp': formatTimestamp(record.timestamp),
-      if (fields != null && fields.isNotEmpty) ...fields,
-    };
+    final dict = Map.fromEntries([
+      MapEntry('level', formatLevel(record.level)),
+      MapEntry('message', record.message),
+      MapEntry('name', record.name),
+      MapEntry('timestamp', formatTimestamp(record.timestamp)),
+      ...?_formatFields(record.fields),
+    ]);
 
     return _utf8.convert(_json.convert(dict));
   }
-}
-
-Map<String, dynamic> _formatLevel(Level level) =>
-    <String, dynamic>{'name': level.name, 'severity': level.value};
-
-String _formatTimestamp(DateTime timestamp) => timestamp.toString();
-
-Map<String, dynamic> _formatFields(Iterable<Field> fields) {
-  final dict = <String, dynamic>{};
-
-  if (fields != null) {
-    for (final field in fields) {
-      switch (field.kind) {
-        case FieldKind.object:
-          dict[field.name] = _formatFields((field as Obj).value);
-          break;
-
-        default:
-          dict[field.name] = field.value.toString();
-          break;
-      }
-    }
-  }
-
-  return dict;
 }

--- a/lib/src/handler.dart
+++ b/lib/src/handler.dart
@@ -11,6 +11,7 @@ abstract class Handler {
   /// Sets subscription to a specific logger.
   ///
   /// DO NOT set this field directly.
+  /// @nodoc
   set subscription(StreamSubscription<Record> subscription) =>
       _subscription = subscription;
 

--- a/lib/src/logging_context.dart
+++ b/lib/src/logging_context.dart
@@ -29,8 +29,8 @@ class LoggingContext implements Interface {
   @override
   @pragma('vm:prefer-inline')
   Interface bind([Iterable<Field> fields]) => LoggingContext(_logger, {
-        if (fields != null) ...fields,
-        if (_fields != null) ..._fields,
+        ...?fields,
+        ...?_fields,
       });
 
   @override

--- a/test/formatter_test.dart
+++ b/test/formatter_test.dart
@@ -1,0 +1,44 @@
+import 'package:test/test.dart';
+import 'package:jetlog/jetlog.dart' show Field, FieldKind;
+import 'package:jetlog/formatters.dart' show FormatterBase;
+
+class CustomFormatter with FormatterBase<String> {}
+
+void main() {
+  group('FormatterBase', () {
+    group('#getFieldFormatter', () {
+      test('it returns normally', () {
+        final f = CustomFormatter();
+
+        expect(() => f.setFieldFormatter(FieldKind.number, (field) => '$field'),
+            returnsNormally);
+
+        // Twice
+        expect(
+            () => f.setFieldFormatter(FieldKind.boolean, (field) => '$field'),
+            returnsNormally);
+        expect(
+            () => f.setFieldFormatter(FieldKind.boolean, (field) => '$field'),
+            returnsNormally);
+      });
+    });
+
+    group('#setFieldFormatter', () {
+      test('it works', () {
+        final f = CustomFormatter();
+        String handler(Field field) => '$field';
+
+        expect(() => f.setFieldFormatter(FieldKind.double, handler),
+            returnsNormally);
+        expect(f.getFieldFormatter(FieldKind.double), handler);
+      });
+
+      test('it throws if no formatters registered for given field kind', () {
+        final f = CustomFormatter();
+
+        expect(() => f.getFieldFormatter(FieldKind.double),
+            throwsA(const TypeMatcher<StateError>()));
+      });
+    });
+  });
+}

--- a/test/json_formatter_test.dart
+++ b/test/json_formatter_test.dart
@@ -2,7 +2,7 @@ import 'dart:convert' show utf8, json, JsonEncoder;
 
 import 'package:jetlog/formatters.dart' show JsonFormatter;
 import 'package:jetlog/jetlog.dart'
-    show Dur, DTM, Str, Record, Obj, Field, Level, Loggable;
+    show DTM, Dur, Field, FieldKind, Level, Loggable, Obj, Record, Str;
 import 'package:jetlog/src/record_impl.dart';
 import 'package:test/test.dart';
 
@@ -83,41 +83,54 @@ void main() {
       expect(dict, equals(json.decode(utf8.decode(result))));
     });
 
-//    test('uses custom fields formatter', () {
-//      final formatter = JsonFormatter(
-//          formatFields: (fields) => <String, dynamic>{'foo': 'bar'});
-//      final result = formatter(record);
-//
-//      final dict = {
-//        'name': null,
-//        'level': {
-//          'severity': level.value,
-//          'name': level.name,
-//        },
-//        'message': message,
-//        'timestamp': timestamp.toString(),
-//        'foo': 'bar'
-//      };
-//
-//      expect(dict, equals(json.decode(utf8.decode(result))));
-//    });
+    test('uses custom fields encoders', () {
+      final formatter = JsonFormatter()
+        ..setFieldFormatter(
+            FieldKind.dateTime, (_) => const MapEntry('foo', 'bar'));
+      final record = RecordImpl(
+          name: null,
+          timestamp: timestamp,
+          level: level,
+          message: message,
+          fields: [DTM('dateTime', DateTime.now())]);
+      final result = formatter(record);
 
-//    test('does not throw on null fields', () {
-//      final formatter = JsonFormatter(formatFields: (fields) => null);
-//      final result = formatter(record);
-//
-//      final dict = {
-//        'name': null,
-//        'level': {
-//          'severity': level.value,
-//          'name': level.name,
-//        },
-//        'message': message,
-//        'timestamp': timestamp.toString(),
-//      };
-//
-//      expect(dict, equals(json.decode(utf8.decode(result))));
-//    });
+      final dict = {
+        'name': null,
+        'level': {
+          'severity': level.value,
+          'name': level.name,
+        },
+        'message': message,
+        'timestamp': timestamp.toString(),
+        'foo': 'bar'
+      };
+
+      expect(dict, equals(json.decode(utf8.decode(result))));
+    });
+
+    test('does not throw on null fields', () {
+      final formatter = JsonFormatter();
+      final record = RecordImpl(
+          name: null,
+          timestamp: timestamp,
+          level: level,
+          message: message,
+          fields: null);
+      final result = formatter(record);
+
+      final dict = {
+        'name': null,
+        'level': {
+          'severity': level.value,
+          'name': level.name,
+        },
+        'message': message,
+        'timestamp': timestamp.toString(),
+      };
+
+      expect(dict, equals(json.decode(utf8.decode(result))));
+    });
 
     test('uses custom timestamps formatter', () {
       final newTimestamp = DateTime.now();
@@ -199,6 +212,46 @@ void main() {
       };
 
       expect(utf8.decode(result), json.encode(dict));
+    });
+
+    test('defines formatters for all builtin field kinds', () {
+      final formatter1 = JsonFormatter();
+
+      expect(() => formatter1.getFieldFormatter(FieldKind.boolean),
+          returnsNormally);
+      expect(() => formatter1.getFieldFormatter(FieldKind.dateTime),
+          returnsNormally);
+      expect(() => formatter1.getFieldFormatter(FieldKind.double),
+          returnsNormally);
+      expect(() => formatter1.getFieldFormatter(FieldKind.duration),
+          returnsNormally);
+      expect(() => formatter1.getFieldFormatter(FieldKind.integer),
+          returnsNormally);
+      expect(() => formatter1.getFieldFormatter(FieldKind.number),
+          returnsNormally);
+      expect(() => formatter1.getFieldFormatter(FieldKind.object),
+          returnsNormally);
+      expect(() => formatter1.getFieldFormatter(FieldKind.string),
+          returnsNormally);
+
+      final formatter2 = JsonFormatter.withIndent(4);
+
+      expect(() => formatter2.getFieldFormatter(FieldKind.boolean),
+          returnsNormally);
+      expect(() => formatter2.getFieldFormatter(FieldKind.dateTime),
+          returnsNormally);
+      expect(() => formatter2.getFieldFormatter(FieldKind.double),
+          returnsNormally);
+      expect(() => formatter2.getFieldFormatter(FieldKind.duration),
+          returnsNormally);
+      expect(() => formatter2.getFieldFormatter(FieldKind.integer),
+          returnsNormally);
+      expect(() => formatter2.getFieldFormatter(FieldKind.number),
+          returnsNormally);
+      expect(() => formatter2.getFieldFormatter(FieldKind.object),
+          returnsNormally);
+      expect(() => formatter2.getFieldFormatter(FieldKind.string),
+          returnsNormally);
     });
   });
 }

--- a/test/json_formatter_test.dart
+++ b/test/json_formatter_test.dart
@@ -7,16 +7,20 @@ import 'package:jetlog/src/record_impl.dart';
 import 'package:test/test.dart';
 
 class Klass extends Loggable {
-  Klass(this.dur, this.name);
+  Klass(this.dur, this.name, [this.klass]);
 
   final String name;
   final Duration dur;
+  final Klass klass;
 
   @override
   Iterable<Field> toFields() {
     final result = <Field>{};
 
-    result..add(Str('name', name))..add(Dur('dur', dur));
+    result
+      ..add(Str('name', name))
+      ..add(Dur('dur', dur))
+      ..add(Obj('klass', klass));
 
     return result;
   }
@@ -79,41 +83,41 @@ void main() {
       expect(dict, equals(json.decode(utf8.decode(result))));
     });
 
-    test('uses custom fields formatter', () {
-      final formatter = JsonFormatter(
-          formatFields: (fields) => <String, dynamic>{'foo': 'bar'});
-      final result = formatter(record);
+//    test('uses custom fields formatter', () {
+//      final formatter = JsonFormatter(
+//          formatFields: (fields) => <String, dynamic>{'foo': 'bar'});
+//      final result = formatter(record);
+//
+//      final dict = {
+//        'name': null,
+//        'level': {
+//          'severity': level.value,
+//          'name': level.name,
+//        },
+//        'message': message,
+//        'timestamp': timestamp.toString(),
+//        'foo': 'bar'
+//      };
+//
+//      expect(dict, equals(json.decode(utf8.decode(result))));
+//    });
 
-      final dict = {
-        'name': null,
-        'level': {
-          'severity': level.value,
-          'name': level.name,
-        },
-        'message': message,
-        'timestamp': timestamp.toString(),
-        'foo': 'bar'
-      };
-
-      expect(dict, equals(json.decode(utf8.decode(result))));
-    });
-
-    test('does not throw on null fields', () {
-      final formatter = JsonFormatter(formatFields: (fields) => null);
-      final result = formatter(record);
-
-      final dict = {
-        'name': null,
-        'level': {
-          'severity': level.value,
-          'name': level.name,
-        },
-        'message': message,
-        'timestamp': timestamp.toString(),
-      };
-
-      expect(dict, equals(json.decode(utf8.decode(result))));
-    });
+//    test('does not throw on null fields', () {
+//      final formatter = JsonFormatter(formatFields: (fields) => null);
+//      final result = formatter(record);
+//
+//      final dict = {
+//        'name': null,
+//        'level': {
+//          'severity': level.value,
+//          'name': level.name,
+//        },
+//        'message': message,
+//        'timestamp': timestamp.toString(),
+//      };
+//
+//      expect(dict, equals(json.decode(utf8.decode(result))));
+//    });
 
     test('uses custom timestamps formatter', () {
       final newTimestamp = DateTime.now();
@@ -137,7 +141,7 @@ void main() {
     });
 
     test('support indentation', () {
-      final formatter = JsonFormatter(indent: 4);
+      final formatter = JsonFormatter.withIndent(4);
       final result = formatter(record);
 
       final dict = {
@@ -166,7 +170,10 @@ void main() {
           fields: [
             const Dur('dur', Duration.zero),
             DTM('dtm', timestamp),
-            Obj('klass', Klass(Duration.zero, 'test'))
+            Obj(
+                'klass',
+                Klass(
+                    Duration.zero, 'test', Klass(Duration.zero, 'nested-test')))
           ]);
       final result = formatter(record);
 
@@ -183,6 +190,11 @@ void main() {
         'klass': {
           'name': 'test',
           'dur': Duration.zero.toString(),
+          'klass': {
+            'name': 'nested-test',
+            'dur': Duration.zero.toString(),
+            'klass': null,
+          }
         }
       };
 

--- a/test/text_formatter_test.dart
+++ b/test/text_formatter_test.dart
@@ -2,7 +2,7 @@ import 'dart:convert' show utf8;
 
 import 'package:jetlog/formatters.dart' show TextFormatter;
 import 'package:jetlog/jetlog.dart'
-    show Dur, DTM, Str, Obj, Field, Level, Loggable;
+    show DTM, Dur, Field, FieldKind, Level, Loggable, Obj, Str;
 import 'package:jetlog/src/record_impl.dart';
 import 'package:test/test.dart';
 
@@ -140,22 +140,43 @@ void main() {
       expect(utf8.decode(result), '${timestamp.millisecondsSinceEpoch}\r\n');
     });
 
-//    test('uses custom field encoder', () {
-//      final encoder = TextFormatter(
-//          (name, timestamp, level, message, fields) => '$fields',
-//          formatFields: (fields) => 'fields');
-//
-//      final timestamp = DateTime.now();
-//      final record = RecordImpl(
-//          name: null,
-//          timestamp: timestamp,
-//          level: Level.info,
-//          message: '',
-//          fields: const [Dur('dur', Duration.zero)]);
-//
-//      final result = encoder.call(record);
-//
-//      expect(utf8.decode(result), 'fields\r\n');
-//    });
+    test('uses custom field encoder', () {
+      final encoder =
+          TextFormatter((name, timestamp, level, message, fields) => '$fields')
+            ..setFieldFormatter(FieldKind.duration, (field) => 'custom-field');
+
+      final timestamp = DateTime.now();
+      final record = RecordImpl(
+          name: null,
+          timestamp: timestamp,
+          level: Level.info,
+          message: '',
+          fields: const [Dur('dur', Duration.zero)]);
+
+      final result = encoder.call(record);
+
+      expect(utf8.decode(result), 'custom-field\r\n');
+    });
+
+    test('defines formatters for all builtin field kinds', () {
+      final formatter = TextFormatter.defaultFormatter;
+
+      expect(() => formatter.getFieldFormatter(FieldKind.boolean),
+          returnsNormally);
+      expect(() => formatter.getFieldFormatter(FieldKind.dateTime),
+          returnsNormally);
+      expect(
+          () => formatter.getFieldFormatter(FieldKind.double), returnsNormally);
+      expect(() => formatter.getFieldFormatter(FieldKind.duration),
+          returnsNormally);
+      expect(() => formatter.getFieldFormatter(FieldKind.integer),
+          returnsNormally);
+      expect(
+          () => formatter.getFieldFormatter(FieldKind.number), returnsNormally);
+      expect(
+          () => formatter.getFieldFormatter(FieldKind.object), returnsNormally);
+      expect(
+          () => formatter.getFieldFormatter(FieldKind.string), returnsNormally);
+    });
   });
 }

--- a/test/text_formatter_test.dart
+++ b/test/text_formatter_test.dart
@@ -7,16 +7,20 @@ import 'package:jetlog/src/record_impl.dart';
 import 'package:test/test.dart';
 
 class Klass extends Loggable {
-  Klass(this.dur, this.name);
+  Klass(this.dur, this.name, [this.klass]);
 
   final String name;
   final Duration dur;
+  final Klass klass;
 
   @override
   Iterable<Field> toFields() {
     final result = <Field>{};
 
-    result..add(Str('name', name))..add(Dur('dur', dur));
+    result
+      ..add(Str('name', name))
+      ..add(Dur('dur', dur))
+      ..add(Obj('subclass', klass));
 
     return result;
   }
@@ -84,7 +88,8 @@ void main() {
       final timestamp = DateTime.now();
       const level = Level.info;
       const message = 'Test';
-      final klass = Klass(Duration.zero, '__name__');
+      final klass =
+          Klass(Duration.zero, '__name__', Klass(Duration.zero, '__name__'));
       final record = RecordImpl(
           name: null,
           timestamp: timestamp,
@@ -102,7 +107,8 @@ void main() {
           utf8.decode(result),
           '${level.name} ${timestamp.toString()} $message '
           'dur=0:00:00.000000 dtm=$timestamp '
-          'klass.name=__name__ klass.dur=0:00:00.000000\r\n');
+          'klass.name=__name__ klass.dur=0:00:00.000000 '
+          'klass.subclass.name=__name__ klass.subclass.dur=0:00:00.000000 klass.subclass.subclass=null\r\n');
     });
 
     test('uses custom level encoder', () {
@@ -134,22 +140,22 @@ void main() {
       expect(utf8.decode(result), '${timestamp.millisecondsSinceEpoch}\r\n');
     });
 
-    test('uses custom field encoder', () {
-      final encoder = TextFormatter(
-          (name, timestamp, level, message, fields) => '$fields',
-          formatFields: (fields) => 'fields');
-
-      final timestamp = DateTime.now();
-      final record = RecordImpl(
-          name: null,
-          timestamp: timestamp,
-          level: Level.info,
-          message: '',
-          fields: const [Dur('dur', Duration.zero)]);
-
-      final result = encoder.call(record);
-
-      expect(utf8.decode(result), 'fields\r\n');
-    });
+//    test('uses custom field encoder', () {
+//      final encoder = TextFormatter(
+//          (name, timestamp, level, message, fields) => '$fields',
+//          formatFields: (fields) => 'fields');
+//
+//      final timestamp = DateTime.now();
+//      final record = RecordImpl(
+//          name: null,
+//          timestamp: timestamp,
+//          level: Level.info,
+//          message: '',
+//          fields: const [Dur('dur', Duration.zero)]);
+//
+//      final result = encoder.call(record);
+//
+//      expect(utf8.decode(result), 'fields\r\n');
+//    });
   });
 }


### PR DESCRIPTION
Previously it was possible to set custom `formatFields` callback function in order to provide own custom logic for certain field kind. With such approach if you'd like to extend/change handling of specific kind you still need to redefine handling logic for all fields which is suboptimal. This PR includes changes allowing to set/replace only certain field kind(s) without overwriting all others.